### PR TITLE
Publish release notes from tagged builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
+          body_path: RELEASE_NOTES.md
           files: dist/*.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || github.token }}


### PR DESCRIPTION
## Summary
- Attach RELEASE_NOTES.md to tagged GitHub releases.
- Keeps release pages aligned with the installer and standalone artifacts built by the workflow.

## Verification
- npm run lint