### PR TITLE
Keep release tags aligned with packaged versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,20 +47,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
 
-  bump-version:
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.ref == 'refs/heads/main'
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Bump version and push tag
-        uses: anothrNick/github-tag-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
-          WITH_V: true
-          DEFAULT_BUMP: patch

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# DesktopClaw v0.1.0 Release Notes
+# DesktopClaw v0.1.1 Release Notes
 
 Changes since `v0.0.10`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktopclaw",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktopclaw",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "electron": "^39.8.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktopclaw",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenClaw Desktop Pet - Electron MVP",
   "main": "src/main/main.js",
   "author": "OpenClaw",


### PR DESCRIPTION
## Summary
- Bump package metadata to 0.1.1 so release artifacts match the release tag.
- Remove automatic patch-tag creation from main pushes.
- Keep RELEASE_NOTES.md aligned with v0.1.1.

## Verification
- npm run lint
- package.json and package-lock.json parse check