### PR TITLE
Let the release action publish artifacts once

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,7 @@ jobs:
         run: npm install
 
       - name: Build Windows installer
-        run: npm run dist
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+        run: npm run dist -- --publish never
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Disable electron-builder auto-publish during CI builds.
- Keep GitHub Release creation in action-gh-release so RELEASE_NOTES.md is applied.
- Avoid duplicate installer/standalone assets.

## Verification
- npm run lint