### PR TITLE
Use an explicit no-publish release build command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm install
 
       - name: Build Windows installer
-        run: npm run dist -- --publish never
+        run: npx electron-builder --win nsis portable --publish never
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Replace ambiguous npm argument forwarding with a direct electron-builder command.
- Keep release publishing owned by action-gh-release so RELEASE_NOTES.md is applied.

## Verification
- npx electron-builder --win nsis portable --publish never
- npm run lint